### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-##Introduction
+## Introduction
 A demo for the Auto Layout and Flip Animation.It's written in Swift and looks not bad ：）.
 
 
 
 
-##Effects
+## Effects
 
 <li> Flip animation
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
